### PR TITLE
Correct pattern matching

### DIFF
--- a/lib/admissions/registrar.ex
+++ b/lib/admissions/registrar.ex
@@ -20,7 +20,7 @@ defmodule Admissions.Registrar do
   end
 
   defp contributor?(client, nickname, org, repo) do
-    with {_status_code, contributors, _http_response} <- Contributors.list(client, org, repo)
+    with contributors when is_list(contributors) <- Contributors.list(client, org, repo)
     do
       Enum.any?(contributors, &(Map.get(&1, "login") == nickname))
     else

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -50,10 +50,10 @@ msgstr ""
 
 #, elixir-format
 #: lib/admissions_web/templates/registrar/eligible.html.eex:2
-msgid "eligible_title"
+msgid "eligible_title %{nickname}"
 msgstr ""
 
 #, elixir-format
 #: lib/admissions_web/templates/registrar/ineligible.html.eex:2
-msgid "eligible_title %{nickname}"
+msgid "ineligible_title"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -58,3 +58,8 @@ msgstr "Thank you for your contributions, this wouldn’t be the same without yo
 #: lib/admissions_web/templates/registrar/ineligible.html.eex:2
 msgid "eligible_title %{nickname}"
 msgstr "🎉 You're eligible, %{nickname}!"
+
+#, elixir-format
+#: lib/admissions_web/templates/registrar/ineligible.html.eex:2
+msgid "ineligible_title"
+msgstr "Currently ineligible"


### PR DESCRIPTION
Contrary to the documentation the result is actually a list:

```elixir
client
|> Tentacat.Repositories.Contributors.list("elixirschool", "elixirschool") 
|> Enum.map(&Map.get(&1, "login"))
["doomspork", "nscyclone", "brain-geek", "Koziolek", "gemantzu",
 "eksperimental", "pragmaticivan", "riseshia", "fabon-f", "marocchino",
 "thiamsantos", "gavlak", "michalvalasek", "rezaprima", "3100", "pjhampton",
 "SophieDeBenedetto", "devleoper", "zillou", "erickgnavar", "cizixs",
 "rafalbig", "kenspirit", "milmazz", "joneslee85", "andreapavoni",
 "code-shoily", "Dalgona", "dabielf", "anderkonzen", "malkoG", "crabonature",
 "yasinyaman", "ybur-yug", "scouten", "jinyeow", "julienXX", "Devalo",
 "Tsuyoshi84", "burden", "lithiumpie", "iguchi1124", "edwinallenz", "kalarani",
 "aquarhead", "psantos10", "ybod", "yyyc514", "kdebowski", "kianmeng", ...]
```