### PR TITLE
Updating ineligible message after failed login

### DIFF
--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -37,7 +37,7 @@ msgstr "Welcome to Elixir School Slack!"
 #, elixir-format
 #: lib/admissions_web/templates/registrar/ineligible.html.eex:8
 msgid "ineligible_content"
-msgstr "At this time Slack invitations are reserved for contributors.\nIf you feel this is a mistake, let us know on Twitter @elixirschool."
+msgstr "At this time Slack invitations are reserved for contributors.\nIf you feel this is a mistake, let us know on Twitter @elixirschool.\nPlease note that if you have contributed for the first time to Elixir School, it might take around 30 minutes for GitHub to update their records.\nWe do apologise any inconvenience."
 
 #, elixir-format
 #: lib/admissions_web/templates/registrar/ineligible.html.eex:5

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -37,7 +37,7 @@ msgstr "Welcome to Elixir School Slack!"
 #, elixir-format
 #: lib/admissions_web/templates/registrar/ineligible.html.eex:8
 msgid "ineligible_content"
-msgstr "At this time Slack invitations are reserved for contributors.\nIf you feel this is a mistake, let us know on Twitter @elixirschool.\nPlease note that if you have contributed for the first time to Elixir School, it might take around 30 minutes for GitHub to update their records.\nWe do apologise any inconvenience."
+msgstr "At this time Slack invitations are reserved for contributors.\nIf you feel this is a mistake, let us know on Twitter @elixirschool.\nPlease note that if you have contributed for the first time to Elixir School, it may take up to an hour for GitHub to update their records.\nWe do apologise any inconvenience."
 
 #, elixir-format
 #: lib/admissions_web/templates/registrar/ineligible.html.eex:5


### PR DESCRIPTION
If a user has very recently contributed to Elixir School and tries to Sign-in, GitHub might not have updated their records yet and therefore not give access to the user.

Updating the error message to mension this issue.